### PR TITLE
chore(toolkit): update Doctor bootstrap

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -92,7 +92,6 @@ jobs:
       analyze_day: ${{ steps.collect.outputs.analyze_day }}
       report_tz: ${{ steps.collect.outputs.report_tz }}
       observed_findings_present: ${{ steps.collect.outputs.observed_findings_present }}
-      findings_artifact_name: ${{ steps.collect.outputs.findings_artifact_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -128,7 +127,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.collect.outputs.findings_artifact_name }}
+          name: doctor-findings
           path: ${{ runner.temp }}/doctor/doctor-findings.json
           if-no-files-found: error
 
@@ -149,7 +148,7 @@ jobs:
       - name: Download doctor-findings artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.collect.outputs.findings_artifact_name }}
+          name: doctor-findings
           path: ${{ runner.temp }}/doctor-findings
 
       - name: Checkout toolkit source
@@ -214,7 +213,7 @@ jobs:
       report_tz: ${{ needs.collect.outputs.report_tz }}
       issues_enabled: ${{ github.event.repository.has_issues && 'true' || 'false' }}
       observed_findings_present: ${{ needs.collect.outputs.observed_findings_present }}
-      findings_artifact_name: ${{ needs.collect.outputs.findings_artifact_name }}
+      findings_artifact_name: doctor-findings
       source_sha: ${{ needs.collect.outputs.source_sha }}
       installed_source_sha: ${{ needs.collect.outputs.installed_source_sha }}
       installed_runtime_sha: ${{ needs.collect.outputs.installed_runtime_sha }}
@@ -238,7 +237,7 @@ jobs:
       issues: write
       pull-requests: write
       discussions: write
-    uses: G-Core/agent-toolkit/.github/workflows/doctor-analyze-codex.lock.yml@main
+    uses: G-Core/agent-toolkit/.github/workflows/doctor-analyze-codex.lock.yml@doctor-v1
     secrets:
       CODEX_API_KEY: ${{ secrets[vars.DOCTOR_OPENAI_SECRET_NAME || 'OPENAI_API_KEY'] || secrets.OPENAI_API_KEY }}
       OPENAI_API_KEY: ${{ secrets[vars.DOCTOR_OPENAI_SECRET_NAME || 'OPENAI_API_KEY'] || secrets.OPENAI_API_KEY }}
@@ -250,7 +249,7 @@ jobs:
       report_tz: ${{ needs.collect.outputs.report_tz }}
       issues_enabled: ${{ github.event.repository.has_issues && 'true' || 'false' }}
       observed_findings_present: ${{ needs.collect.outputs.observed_findings_present }}
-      findings_artifact_name: ${{ needs.collect.outputs.findings_artifact_name }}
+      findings_artifact_name: doctor-findings
       source_sha: ${{ needs.collect.outputs.source_sha }}
       installed_source_sha: ${{ needs.collect.outputs.installed_source_sha }}
       installed_runtime_sha: ${{ needs.collect.outputs.installed_runtime_sha }}


### PR DESCRIPTION
## Summary

- Replace the old mixed-ref Doctor workflow bootstrap with the current standard bootstrap from G-Core/agent-toolkit
- Use the stable doctor-findings artifact name
- Remove dynamic findings_artifact_name job output usage
- Keep Doctor runtime refs on doctor-v1, including Codex analyze

## Context

The current workflow has mixed analyze refs: Claude analyze uses doctor-v1 while Codex analyze points at main. This PR normalizes the bootstrap to the standard doctor-v1 version.

## Checks

- git diff --check
- verified doctor-findings is present
- verified dynamic findings_artifact_name output references are absent
- verified @main analyze refs are absent
- verified doctor-v1 refs are preserved